### PR TITLE
Support new COOL environment structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ No modules.
 | stakeholders\_table\_sort\_key\_type | The data type of the stakeholders DynamoDB table sort (range) key.  See `https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypeDescriptors` for a list of valid values. | `string` | `"S"` | no |
 | stakeholders\_table\_write\_capacity | The number of write units for the stakeholders DynamoDB table. | `number` | `5` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/backend.tf
+++ b/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "cool-userservices-was-db/terraform.tfstate"

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -8,36 +8,28 @@ data "terraform_remote_state" "master" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts/master.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts/master.tfstate"
   }
 
-  # There is only one environment for this account, so there is
-  # no need to match the current Terraform workspace.
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "userservices" {
   backend = "s3"
 
   config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    bucket         = var.terraform_state_bucket
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "cool-accounts-userservices/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "cool-accounts-userservices/terraform.tfstate"
   }
 
-  # We typically use data from this remote state to determine if the User
-  # Services account is in staging or production, but since we need to specify
-  # the correct workspace below in order to define this remote state, we must
-  # instead rely on the name of our current Terraform workspace; it must match
-  # the name of one of the workspaces in cool-accounts-userservices (e.g.
-  # staging, production).
   workspace = terraform.workspace
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
+  type        = string
+}
+
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes updates in support of the switchover from our legacy account/environment scheme (where staging and production accounts exist within the same AWS organization) to our new scheme (where they do not).

Highlights include:
* Removal of hard-coded references to production resources
* Use of [partial backend configurations](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The goal of this PR is to get us closer to our modernized account scheme where there is no more co-mingling of staging and production accounts.  Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this updated Terraform in dev-a, staging-a, and production environments and everything looks as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
